### PR TITLE
av: Clean up QCOM build flags

### DIFF
--- a/media/libmediaplayerservice/nuplayer/Android.mk
+++ b/media/libmediaplayerservice/nuplayer/Android.mk
@@ -36,10 +36,6 @@ LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/mm-audio
 LOCAL_CFLAGS += -DQTI_FLAC_DECODER
 endif
 
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_PCM_OFFLOAD)),true)
-LOCAL_CFLAGS += -DPCM_OFFLOAD_ENABLED
-endif
-
 endif
 
 LOCAL_MODULE:= libstagefright_nuplayer

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -147,6 +147,8 @@ LOCAL_STATIC_LIBRARIES := \
         libFLAC \
         libmedia_helper
 
+ifeq ($(call is-vendor-board-platform,QCOM),true)
+
 ifeq ($(TARGET_USES_QCOM_BSP), true)
     LOCAL_C_INCLUDES += $(call project-path-for,qcom-display)/libgralloc
     LOCAL_CFLAGS += -DQCOM_BSP
@@ -161,17 +163,10 @@ ifeq ($(TARGET_ENABLE_QC_AV_ENHANCEMENTS),true)
        LOCAL_SRC_FILES  += FMA2DPWriter.cpp
 endif #TARGET_ENABLE_AV_ENHANCEMENTS
 
-ifeq ($(call is-vendor-board-platform,QCOM),true)
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_PCM_OFFLOAD_24)),true)
-       LOCAL_CFLAGS     += -DPCM_OFFLOAD_ENABLED_24
-       LOCAL_C_INCLUDES += $(TOP)/$(call project-path-for,qcom-media)/mm-core/inc
-endif
-endif
-
-ifeq ($(call is-vendor-board-platform,QCOM),true)
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_FLAC_OFFLOAD)),true)
        LOCAL_CFLAGS     += -DFLAC_OFFLOAD_ENABLED
 endif
+
 endif
 
 LOCAL_SHARED_LIBRARIES += \

--- a/media/libstagefright/Utils.cpp
+++ b/media/libstagefright/Utils.cpp
@@ -40,9 +40,7 @@
 #ifdef ENABLE_AV_ENHANCEMENTS
 #include "QCMediaDefs.h"
 #include "QCMetaData.h"
-#if defined(FLAC_OFFLOAD_ENABLED) || defined(PCM_OFFLOAD_ENABLED_24)
 #include "audio_defs.h"
-#endif
 #endif
 
 namespace android {

--- a/services/audiopolicy/Android.mk
+++ b/services/audiopolicy/Android.mk
@@ -1,10 +1,12 @@
 LOCAL_PATH:= $(call my-dir)
 
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_COMPRESS_VOIP)),true)
+ifeq ($(call is-vendor-board-platform,QCOM),true)
+
+ifneq ($(strip $(AUDIO_FEATURE_ENABLED_COMPRESS_VOIP)),false)
 common_cflags += -DAUDIO_EXTN_COMPRESS_VOIP_ENABLED
 endif
 
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_EXTN_FORMATS)),true)
+ifneq ($(strip $(AUDIO_FEATURE_ENABLED_EXTN_FORMATS)),false)
 common_cflags += -DAUDIO_EXTN_FORMATS_ENABLED
 endif
 
@@ -16,7 +18,7 @@ ifeq ($(strip $(AUDIO_FEATURE_ENABLED_HDMI_SPK)),true)
 common_cflags += -DAUDIO_EXTN_HDMI_SPK_ENABLED
 endif
 
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_INCALL_MUSIC)),true)
+ifneq ($(strip $(AUDIO_FEATURE_ENABLED_INCALL_MUSIC)),false)
 common_cflags += -DAUDIO_EXTN_INCALL_MUSIC_ENABLED
 endif
 
@@ -24,11 +26,7 @@ ifeq ($(strip $(AUDIO_FEATURE_ENABLED_MULTIPLE_TUNNEL)), true)
 common_cflags += -DMULTIPLE_OFFLOAD_ENABLED
 endif
 
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_PCM_OFFLOAD)),true)
-common_cflags += -DPCM_OFFLOAD_ENABLED
-endif
-
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_PROXY_DEVICE)),true)
+ifneq ($(strip $(AUDIO_FEATURE_ENABLED_PROXY_DEVICE)),false)
 common_cflags += -DAUDIO_EXTN_AFE_PROXY_ENABLED
 endif
 
@@ -58,6 +56,8 @@ endif #DOLBY_END
 
 ifeq ($(TARGET_ENABLE_QC_AV_ENHANCEMENTS),true)
 common_cflags += -DENABLE_AV_ENHANCEMENTS
+endif
+
 endif
 
 include $(CLEAR_VARS)


### PR DESCRIPTION
- Remove dead flags
- Enable standard flags by default

Change-Id: I15b4743a2569360dcb5798f2f1d8f4390a68899a
