### PR TITLE
nuplayer: Avoid PCM offload when resampler is used

### DIFF
--- a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
@@ -1394,8 +1394,11 @@ bool NuPlayer::Renderer::onOpenAudioSink(
     pcmOffload = ExtendedUtils::isPcmOffloadEnabled() &&
             !strcasecmp(mime.c_str(), MEDIA_MIMETYPE_AUDIO_RAW);
 
+    int32_t resampled = 0;
+    format->findInt32("resampled", &resampled);
+
     // At this point we can check if PCM should be offloaded
-    if (!offloadingAudio() && (!offloadOnly && pcmOffload)) {
+    if (!offloadingAudio() && (!offloadOnly && pcmOffload && !resampled)) {
         sp<MetaData> aMeta = new MetaData;
         convertMessageToMetaData(format, aMeta);
         if  (canOffloadStream(aMeta, false, new MetaData,


### PR DESCRIPTION
- We don't support use of the resampler on the PCM offload path,
  this kind of defeats the purpose. While the offload output path
  handles most sample rates, there are cases such as Facebook's
  video preview which use weird formats like 24000KHz mono.
- To resolve this in NuPlayer, compare metadata from the original
  format with the output format decided by the audio system. Fail
  offload if they don't match.

Change-Id: Ibf7c3a2fa4f54b56c39cc69b1ff6b474738ee339
